### PR TITLE
[CMLG-002] fix the bug when converting data from excel to database

### DIFF
--- a/TranslationBackend/app/Imports/TranslationImport.php
+++ b/TranslationBackend/app/Imports/TranslationImport.php
@@ -3,16 +3,30 @@
 namespace App\Imports;
 
 use App\Translation;
+use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
+use Maatwebsite\Excel\Row;
 
-class TranslationImport implements ToModel, WithHeadingRow
+class TranslationImport implements OnEachRow, WithHeadingRow
 {
 
-    public function model(array $row){
-        // store entity set in translations table
-        return new Translation([
-            'name' => $row['en_english'] ?? $row['zh_cn']
-        ]);
+    public function onRow(Row $row)
+    {
+        // rowIndex starts from 2, -1 to make it starts from 1
+        $rowIndex = $row->getIndex() - 1;
+        $row = $row->toArray();
+
+        // check this row contains values
+        $row = array_filter($row, function ($value) { return $value !== null; });
+
+        if ($row) {
+            $translation = new Translation([
+                'id' => $rowIndex,
+                'name' => $row['en_english'] ?? $row['cn']
+            ]);
+            $translation->save();
+        }
+
     }
 }

--- a/TranslationBackend/app/Imports/WordImport.php
+++ b/TranslationBackend/app/Imports/WordImport.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace App\Imports;
+use App\Language;
+use App\Translation;
 use App\Word;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\ToCollection;
@@ -9,17 +11,33 @@ class WordImport implements ToCollection
 {
     public function collection(Collection $rows)
     {
+        $wordIndex = 1;
+        $rows = $rows->toArray();
+
         // store entity set in words table
         // the index of row number is same as translation id
         // the index of column number is same as language id
-        for($i = 1; $i <= count($rows) - 1; $i ++){
-            for($j = 1; $j <= count($rows[$i]); $j ++){
-                $word = new Word([
-                    'name' =>$rows[$i][$j - 1],
-                    'language_id' => $j,
-                    'translation_id' => $i,
-                ]);
-                $word->save();
+        for($i = 1; $i <= count($rows) - 1; $i++){
+
+            // check this row contains values
+            $row = $rows[$i];
+            $filteredRow = array_filter($row, function ($value) { return $value !== null; });
+
+            if($filteredRow) {
+
+                for($j = 0; $j < count($row); $j++){
+
+                    $word = new Word([
+                        'id' => $wordIndex,
+                        'name' =>$row[$j],
+                        'language_id' => $j + 1,
+                        'translation_id' => $i,
+                    ]);
+
+                    $word->save();
+
+                    $wordIndex++;
+                }
             }
         }
     }

--- a/TranslationBackend/app/Imports/WordImport.php
+++ b/TranslationBackend/app/Imports/WordImport.php
@@ -15,23 +15,24 @@ class WordImport implements ToCollection
         $rows = $rows->toArray();
 
         // store entity set in words table
-        // the index of row number is same as translation id
-        // the index of column number is same as language id
-        for($i = 1; $i <= count($rows) - 1; $i++){
+        foreach ($rows as $rowId => $row) {
+            if($rowId == 0) {
+                // the first row is the header
+                continue;
+            }
 
-            // check this row contains values
-            $row = $rows[$i];
+            // check this row contains value
             $filteredRow = array_filter($row, function ($value) { return $value !== null; });
 
-            if($filteredRow) {
+            if ($filteredRow) {
 
-                for($j = 0; $j < count($row); $j++){
+                foreach ($row as $columnId => $word) {
 
                     $word = new Word([
                         'id' => $wordIndex,
-                        'name' =>$row[$j],
-                        'language_id' => $j + 1,
-                        'translation_id' => $i,
+                        'name' => $word,
+                        'language_id' => $columnId + 1,
+                        'translation_id' => $rowId,
                     ]);
 
                     $word->save();

--- a/TranslationBackend/app/Language.php
+++ b/TranslationBackend/app/Language.php
@@ -12,11 +12,14 @@ class Language extends Model
     }
     public function store($data){
         // store entity set in language table
+        $id = 1;
         foreach($data as $languages){
             $language = new Language([
+                'id' => $id,
                 'name' => $languages
             ]);
             $language -> save();
+            $id++;
         }
     }
 }

--- a/TranslationBackend/routes/web.php
+++ b/TranslationBackend/routes/web.php
@@ -18,7 +18,10 @@ Route::get('/', function () {
 });
 
 Route::get('/translations/{word}', 'WordController@show');
-Route::get('/import', 'ImportController@store');
+
+// route below is only used to set up the database, this shouldn't be exposed to the public 
+//Route::get('/import', 'ImportController@store');
+
 // '/translations'
 // '/translations/{word}'
 


### PR DESCRIPTION
**Issue:**

In TranslationImport file, the code is looking for a language with value "zh_cn" while in excel the corresponding language name is 'cn' only.

Excel can contain complete empty rows which will also be read but shouldn't be put into the database.

The index of the data stored in the database sometimes doesn't start with 1.

The /import endpoint shouldn't be exposed to the public.

**Solution:**

Changing the language used in TranslationImport from 'zh_cn' to 'cn' to match the excel sheet.
Adding functions to check if the whole row is completely empty, and only process that row if it contains some data.
Determining the id of each model when inserting it into the database.
Comment out the /import endpoint

**Risk:**
Developers who want to set up a local database themselves need to uncomment the /import endpoint.
Calling the /import endpoint twice will cause an exception being thrown. To reset your database, delete everything in your database first and then call the /import endpoint.

**Reviewed by:**
Eileen, Annie