### PR TITLE
[CMLG-002] update excel sheet and fix the bug regarding to the new version

### DIFF
--- a/TranslationBackend/app/Imports/TranslationImport.php
+++ b/TranslationBackend/app/Imports/TranslationImport.php
@@ -23,7 +23,7 @@ class TranslationImport implements OnEachRow, WithHeadingRow
         if ($row) {
             $translation = new Translation([
                 'id' => $rowIndex,
-                'name' => $row['en_english'] ?? $row['cn']
+                'name' => $row['en_english'] ?? $row['zh_cn']
             ]);
             $translation->save();
         }


### PR DESCRIPTION
Issue: The header name for Chinese language was originally 'cn' in excel sheet, should change it to 'zh_cn' as the client provided.

Solution: Update excel sheet and change the language used in TranslationImport from 'cn' to 'zh_cn'.

Risk: Excel sheet should be manually added to the path 'TranslationBackend\storage\app'

Reviewed by: Annie and Emily.