### PR TITLE
[CMLG-005] adding default string length so migrate can work in server

### DIFF
--- a/TranslationBackend/app/Providers/AppServiceProvider.php
+++ b/TranslationBackend/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -24,5 +25,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         //
+        Schema::defaultStringLength(191);
     }
 }


### PR DESCRIPTION
Issue:

Server has a MariaDB version of 5.5, running migrate:refresh will cause an exception to be thrown.

Solution:

According to https://laravel.com/docs/master/migrations#creating-indexes, if the MariaDB version is order than 5.7.7, adding default string length is needed and will solve this problem.

Risk:
Shouldn't have any risk on local developing, assuming developers have a higher version of MariaDB installed.

Reviewed by:
Annie, Eileen