### PR TITLE
[CMLG-003] sort words by language id in json file

### DIFF
--- a/TranslationBackend/app/Word.php
+++ b/TranslationBackend/app/Word.php
@@ -28,7 +28,7 @@ class Word extends Model
             ->orderBy('language_id', 'asc')
             ->get();
 
-        // group the data by language name and return an JSON file
+        // Return an JSON file
         return $data->toJson();
     }
 

--- a/TranslationBackend/app/Word.php
+++ b/TranslationBackend/app/Word.php
@@ -22,10 +22,10 @@ class Word extends Model
         // selecting the words with the required translation id
         $data = DB::table('words')
             ->join('languages', 'words.language_id', '=', 'languages.id')
-            ->select(['words.name', 'languages.name AS language_name', 'translation_id'])
+            ->select(['words.name', 'languages.id AS language_id', 'languages.name AS language_name', 'translation_id'])
             ->whereIn('translation_id', $translationArray)
             ->orderBy('translation_id', 'asc')
-            ->orderBy('language_name', 'asc')
+            ->orderBy('language_id', 'asc')
             ->get();
 
         // group the data by language name and return an JSON file

--- a/TranslationBackend/routes/web.php
+++ b/TranslationBackend/routes/web.php
@@ -17,21 +17,8 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/translations/{word?}', 'WordController@show'); 
+Route::get('/translations/{word?}', 'WordController@show');
 
-// route below is only used to set up the database, this shouldn't be exposed to the public 
+// route below is only used to set up the database, this shouldn't be exposed to the public
 //Route::get('/import', 'ImportController@store');
 
-// '/translations'
-// '/translations/{word}'
-
-//Potential json file
-// 'english': {
-//     words: {
-//         [
-//             id:1,
-//             name:hi,
-//             translation_id: 1
-//         ]
-//     }
-// }

--- a/TranslationBackend/tests/Feature/WordTest.php
+++ b/TranslationBackend/tests/Feature/WordTest.php
@@ -26,11 +26,13 @@ class WordTest extends TestCase
             ->assertJson([
                 [
                     "name" => "病毒",
+                    "language_id" => "2",
                     "language_name" => "ZH CN",
                     "translation_id" => "1"
                 ],
                 [
                     "name" => "bìngdú",
+                    "language_id" => "3",
                     "language_name" => "pinyin",
                     "translation_id" => "1"
                 ]
@@ -46,21 +48,25 @@ class WordTest extends TestCase
             ->assertJson([
                 [
                     "name" => "病毒",
+                    "language_id" => "2",
                     "language_name" => "ZH CN",
                     "translation_id" => "1"
                 ],
                 [
                     "name" => "bìngdú",
+                    "language_id" => "3",
                     "language_name" => "pinyin",
                     "translation_id" => "1"
                 ],
                 [
                     "name" => "novel coronavirus",
+                    "language_id" => "1",
                     "language_name" => "EN English",
                     "translation_id" => "2"
                 ],
                 [
                     "name" => "xīnxíng guānzhuàng bìngdú (xīnguān bìngdú)",
+                    "language_id" => "3",
                     "language_name" => "pinyin",
                     "translation_id" => "2"
                 ]
@@ -77,26 +83,31 @@ class WordTest extends TestCase
             ->assertJson([
                     [
                         "name" => "病毒",
+                        "language_id" => "2",
                         "language_name" => "ZH CN",
                         "translation_id" => "1"
                     ],
                     [
                         "name" => "bìngdú",
+                        "language_id" => "3",
                         "language_name" => "pinyin",
                         "translation_id" => "1"
                     ],
                     [
                         "name" => "novel coronavirus",
+                        "language_id" => "1",
                         "language_name" => "EN English",
                         "translation_id" => "2"
                     ],
                     [
                         'name' => 'xīnxíng guānzhuàng bìngdú (xīnguān bìngdú)',
+                        "language_id" => "3",
                         "language_name" => "pinyin",
                         "translation_id" => "2"
                     ],
                     [
                         'name' => 'fèiyán',
+                        "language_id" => "3",
                         "language_name" => "pinyin",
                         "translation_id" => "3"
                     ]


### PR DESCRIPTION
Issue:

Words are sorted by translation id first then language name in the json file, which doesn't follow the order of languages in the excel sheet.

Solution:

Select language.id from the table and sort words based on language id instead of the language name.
Update the tests to fit the new JSON schema.

Risk:
/

Reviewed by:
Annie, Eileen