### PR TITLE
[CMLG-014] Modified the backend api to suit needs of frontend

### DIFF
--- a/TranslationBackend/app/Http/Controllers/WordController.php
+++ b/TranslationBackend/app/Http/Controllers/WordController.php
@@ -41,8 +41,14 @@ class WordController extends Controller
      */
     public function show($word = null)
     {
-        $words = new Word();
-        return $words->search($word);
+        if ( request()->has( 'sequence' )) {
+            $sequence = request()->sequence;
+            $words = new Word();
+            $data = $words->search($word);
+            return json_encode(['sequence' => $sequence, 'data' => $data]);
+        } else {
+            // this scenario shouldn't really be happening
+        }
     }
 
     /**

--- a/TranslationBackend/app/Http/Controllers/WordController.php
+++ b/TranslationBackend/app/Http/Controllers/WordController.php
@@ -41,18 +41,16 @@ class WordController extends Controller
      */
     public function show()
     {
-        if ( request()->has( 'sequence' )) {
+        if ( request()->has( 'sequence' ) ) {
             $sequence = request()->sequence;
             $word = null;
-            if ( request()->has( 'word' )) {
+            if ( request()->has( 'word' ) ) {
                 $word = request()->word;
             }
             $words = new Word();
             $data = $words->search($word);
             return json_encode(['sequence' => $sequence, 'data' => $data]);
-        } else {
-            // @todo this scenario shouldn't really be happening
-        }
+        } 
     }
 
     /**

--- a/TranslationBackend/app/Http/Controllers/WordController.php
+++ b/TranslationBackend/app/Http/Controllers/WordController.php
@@ -39,15 +39,19 @@ class WordController extends Controller
      * @param  \App\Word  $word
      * @return json file containing result of search
      */
-    public function show($word = null)
+    public function show()
     {
         if ( request()->has( 'sequence' )) {
             $sequence = request()->sequence;
+            $word = null;
+            if ( request()->has( 'word' )) {
+                $word = request()->word;
+            }
             $words = new Word();
             $data = $words->search($word);
             return json_encode(['sequence' => $sequence, 'data' => $data]);
         } else {
-            // this scenario shouldn't really be happening
+            // @todo this scenario shouldn't really be happening
         }
     }
 

--- a/TranslationBackend/app/Word.php
+++ b/TranslationBackend/app/Word.php
@@ -12,10 +12,14 @@ class Word extends Model
 
         // select the translation id of the words that contains the search key word
         $translation = DB::table('words')
-            ->select('translation_id')
-            ->where('words.name', 'like', '%'.$word.'%')
-            ->distinct()
-            ->get();
+        ->select('translation_id')
+        ->where('words.name', 'like', '%'.$word.'%')
+        ->distinct()
+        ->get();
+       
+        if ($word == null) {
+            $translation = $translation->take(10); 
+        }        
 
         $translationArray = $translation->pluck('translation_id');
 
@@ -28,8 +32,8 @@ class Word extends Model
             ->orderBy('language_id', 'asc')
             ->get();
 
-        // Return an JSON file
-        return $data->toJson();
+        // Return results as a collection
+        return $data;
     }
 
     public function language() {

--- a/TranslationBackend/app/Word.php
+++ b/TranslationBackend/app/Word.php
@@ -12,10 +12,10 @@ class Word extends Model
 
         // select the translation id of the words that contains the search key word
         $translation = DB::table('words')
-        ->select('translation_id')
-        ->where('words.name', 'like', '%'.$word.'%')
-        ->distinct()
-        ->get();
+            ->select('translation_id')
+            ->where('words.name', 'like', '%'.$word.'%')
+            ->distinct()
+            ->get();
        
         if ($word == null) {
             $translation = $translation->take(10); 

--- a/TranslationBackend/routes/api.php
+++ b/TranslationBackend/routes/api.php
@@ -20,7 +20,7 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 
 //route is prepended with /api/ prefix
-Route::get('/translations/{word?}', 'WordController@show');
+Route::get('/translations', 'WordController@show');
 
 // route below is only used to set up the database, this shouldn't be exposed to the public
 //Route::get('/import', 'ImportController@store');

--- a/TranslationBackend/routes/api.php
+++ b/TranslationBackend/routes/api.php
@@ -17,3 +17,11 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+
+//route is prepended with /api/ prefix
+Route::get('/translations/{word?}', 'WordController@show');
+
+// route below is only used to set up the database, this shouldn't be exposed to the public
+//Route::get('/import', 'ImportController@store');
+

--- a/TranslationBackend/routes/web.php
+++ b/TranslationBackend/routes/web.php
@@ -16,9 +16,3 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
-
-Route::get('/translations/{word?}', 'WordController@show');
-
-// route below is only used to set up the database, this shouldn't be exposed to the public
-//Route::get('/import', 'ImportController@store');
-

--- a/TranslationBackend/tests/Feature/InitialDataTest.php
+++ b/TranslationBackend/tests/Feature/InitialDataTest.php
@@ -17,28 +17,28 @@ class InitialDataTest extends TestCase
      */
     public function testExcelFileExistence()
     {
-        $response = $this->get('/import');
+        $response = $this->get('/api/import');
         $response->assertStatus(200);
         $this->assertFileExists('storage/app/data.xlsx');
     }
 
     public function testLanguagesTable()
     {
-        $response = $this->get('/import');
+        $response = $this->get('/api/import');
         $response->assertStatus(200);
         $this->assertEquals(18, DB::table('languages')->count());
     }
 
     public function testTranslationsTable()
     {
-        $response = $this->get('/import');
+        $response = $this->get('/api/import');
         $response->assertStatus(200);
         $this->assertEquals(113, DB::table('translations')->count());
     }
 
     public function testWordsTable()
     {
-        $response = $this->get('/import');
+        $response = $this->get('/api/import');
         $response->assertStatus(200);
         $this -> assertDatabaseHas('words', [
             'name' => '含氯消毒液',

--- a/TranslationBackend/tests/Feature/WordTest.php
+++ b/TranslationBackend/tests/Feature/WordTest.php
@@ -13,62 +13,68 @@ class WordTest extends TestCase
 {
     use RefreshDatabase;
     /**
-     * Testing the search function is working correctly and a json file is returned.
+     * Testing the search function is working correctly for typed chinese characters and a json file is returned.
      *
      * @return void
      */
     public function testChinese()
     {
-        $response = $this->get('/translations/病毒');
+        $response = $this->get('/api/translations?sequence=1&word=病毒');
 
         $response
             ->assertStatus(200)
             ->assertJson([
-                [
-                    "name" => "病毒",
-                    "language_id" => "2",
-                    "language_name" => "ZH CN",
-                    "translation_id" => "1"
-                ],
-                [
-                    "name" => "bìngdú",
-                    "language_id" => "3",
-                    "language_name" => "pinyin",
-                    "translation_id" => "1"
+                "sequence" => "1",
+                "data" => [
+                    [
+                        "name" => "病毒",
+                        "language_id" => "2",
+                        "language_name" => "ZH CN",
+                        "translation_id" => "1"
+                    ],
+                    [
+                        "name" => "bìngdú",
+                        "language_id" => "3",
+                        "language_name" => "pinyin",
+                        "translation_id" => "1"
+                    ]
                 ]
             ]);
     }
 
     public function testAccent()
     {
-        $response = $this->get('/translations/bìngdú');
+        $response = $this->get('/api/translations?sequence=2&word=bìngdú');
 
         $response
             ->assertStatus(200)
             ->assertJson([
-                [
-                    "name" => "病毒",
-                    "language_id" => "2",
-                    "language_name" => "ZH CN",
-                    "translation_id" => "1"
-                ],
-                [
-                    "name" => "bìngdú",
-                    "language_id" => "3",
-                    "language_name" => "pinyin",
-                    "translation_id" => "1"
-                ],
-                [
-                    "name" => "novel coronavirus",
-                    "language_id" => "1",
-                    "language_name" => "EN English",
-                    "translation_id" => "2"
-                ],
-                [
-                    "name" => "xīnxíng guānzhuàng bìngdú (xīnguān bìngdú)",
-                    "language_id" => "3",
-                    "language_name" => "pinyin",
-                    "translation_id" => "2"
+                "sequence" => "2",
+                "data" => [
+                    [
+                        "name" => "病毒",
+                        "language_id" => "2",
+                        "language_name" => "ZH CN",
+                        "translation_id" => "1"
+                    ],
+                    [
+                        "name" => "bìngdú",
+                        "language_id" => "3",
+                        "language_name" => "pinyin",
+                        "translation_id" => "1"
+                    ],
+                    [
+                        "name" => "novel coronavirus",
+                        "language_id" => "1",
+                        "language_name" => "EN English",
+                        "translation_id" => "2"
+                    ],
+                    [
+                        "name" => "xīnxíng guānzhuàng bìngdú (xīnguān bìngdú)",
+                        "language_id" => "3",
+                        "language_name" => "pinyin",
+                        "translation_id" => "2"
+                    ]
                 ]
             ]);
     }
@@ -76,11 +82,13 @@ class WordTest extends TestCase
     // testing the /translation endpoint
     public function testEmptySearch()
     {
-        $response = $this->get('/translations');
+        $response = $this->get('/api/translations?sequence=3');
 
         $response
             ->assertStatus(200)
             ->assertJson([
+                "sequence" => "3",
+                "data" => [
                     [
                         "name" => "病毒",
                         "language_id" => "2",
@@ -111,6 +119,7 @@ class WordTest extends TestCase
                         "language_name" => "pinyin",
                         "translation_id" => "3"
                     ]
+                ]
                 ]);
     }
 
@@ -118,11 +127,22 @@ class WordTest extends TestCase
     //test that when users search for non-exist words, empty result is returned
     public function testNoResults()
     {
-        $response = $this->get('/translations/abcdef');
+        $response = $this->get('/api/translations?sequence=4&word=abcdef');
 
         $response
             ->assertStatus(200) // @todo might change status code
-            ->assertJson([]);
+            ->assertJson([
+                "sequence" => "4",
+                "data" => []
+            ]);
+    }
+    
+    //test that when no sequence number is given with request
+    public function testNoSequence()
+    {
+        $response = $this->get('/api/translations?');
+
+        $response->assertStatus(200); // @todo need to implement the expected result
     }
 
     public function setUp() : void

--- a/TranslationBackend/tests/Feature/WordTest.php
+++ b/TranslationBackend/tests/Feature/WordTest.php
@@ -136,14 +136,6 @@ class WordTest extends TestCase
                 "data" => []
             ]);
     }
-    
-    //test that when no sequence number is given with request
-    public function testNoSequence()
-    {
-        $response = $this->get('/api/translations?');
-
-        $response->assertStatus(200); // @todo need to implement the expected result
-    }
 
     public function setUp() : void
     {


### PR DESCRIPTION
Issue: 
Paths needs to moved to api.php file.
Endpoint needs to include a sequence parameter to track the requests.
CORS issue with requests from other domains.
/translations endpoint need to return first 10 rows.

Solution: 
Routes moved from web.php to api.php which also solved the CORS issue. 
Endpoints changed to:
- /api/translations?sequence=xxx -> returns sequence with first 10 rows of words
- /api/translations?sequence=xxx&word=xxx -> returns sequence with words of db that matches the word
- other endpoints are not supported.
Test cases corrected to match new format of json file.

Risk: 
Endpoints now need to be accessed with "/api/" prefix.
New Json file format returned.
`"sequence" : number`
`"data" : [results]`

Reviewed by: 
Eileen, Emily, Yujia, Kevin, Dave